### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @kinde-starter-kits/giants-kinde
+


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically assign @kinde-starter-kits/giants-kinde as the code owner for all files in this repository.